### PR TITLE
Add support for fetching product by ID

### DIFF
--- a/src/main/java/com/danny/ewf_service/controller/ProductController.java
+++ b/src/main/java/com/danny/ewf_service/controller/ProductController.java
@@ -67,4 +67,13 @@ public class ProductController {
         }
     }
 
+    @GetMapping("/search/{id}")
+    public ResponseEntity<ProductResponseDto> findProductById(@PathVariable Long id) {
+        try {
+            ProductResponseDto product = productService.findById(id);
+            return ResponseEntity.ok().body(product);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
 }

--- a/src/main/java/com/danny/ewf_service/payload/response/ProductResponseDto.java
+++ b/src/main/java/com/danny/ewf_service/payload/response/ProductResponseDto.java
@@ -11,6 +11,7 @@ import lombok.*;
 public class ProductResponseDto {
     private Long id;
     private String sku;
+    private String localSku;
     private Long price;
     private Long localPrice;
     private String images;

--- a/src/main/java/com/danny/ewf_service/repository/ProductRepository.java
+++ b/src/main/java/com/danny/ewf_service/repository/ProductRepository.java
@@ -14,6 +14,9 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p FROM Product p JOIN FETCH p.localProduct WHERE p.sku = :sku")
     Optional<Product> findBySku(@Param("sku") String sku);
 
+    @Query("SELECT p FROM Product p JOIN FETCH p.localProduct WHERE p.id = :id")
+    Optional<Product> findProductById(@Param("id") Long id);
+
     @Query("SELECT p FROM Product p JOIN FETCH p.localProduct WHERE p.category = :category")
     List<Product> findByCategory(@Param("category") String category);
 

--- a/src/main/java/com/danny/ewf_service/service/ProductService.java
+++ b/src/main/java/com/danny/ewf_service/service/ProductService.java
@@ -12,4 +12,6 @@ public interface ProductService {
     List<ProductResponseDto> findAll();
 
     List<ProductSearchResponseDto> getAllProductsSearch();
+
+    ProductResponseDto findById(Long id);
 }

--- a/src/main/java/com/danny/ewf_service/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/danny/ewf_service/service/impl/ProductServiceImpl.java
@@ -42,4 +42,9 @@ public class ProductServiceImpl implements ProductService {
         return productSearchResponseDtoList;
     }
 
+    @Override
+    public ProductResponseDto findById(Long id) {
+        return IProductMapper.INSTANCE.productToProductResponseDto(productRepository.findById(id).orElseThrow());
+    }
+
 }


### PR DESCRIPTION
Introduced a new method to retrieve a product by its ID across service, controller, and repository layers. Updated the mapping logic in `IProductMapper` and extended `ProductResponseDto` to include `localSku`. Additionally, improved image extraction logic for better null safety and resilience.