### PR TITLE
Add update component inventory endpoint

### DIFF
--- a/src/main/java/com/danny/ewf_service/controller/ImportController.java
+++ b/src/main/java/com/danny/ewf_service/controller/ImportController.java
@@ -27,7 +27,7 @@ public class ImportController {
 //            componentsImport.checkSingleProduct();
 //            imagesImport.updateComponentImages();
 //            imagesExport.updateImagesShopifyFromList("houston.csv");
-            componentsImport.importReports();
+//            componentsImport.importReports();
             return ResponseEntity.ok().body("SUCCESS");
         } catch (RuntimeException e) {
             return ResponseEntity.notFound().build();

--- a/src/main/java/com/danny/ewf_service/controller/InventoryController.java
+++ b/src/main/java/com/danny/ewf_service/controller/InventoryController.java
@@ -1,5 +1,6 @@
 package com.danny.ewf_service.controller;
 
+import com.danny.ewf_service.payload.request.ComponentInventoryRequestDto;
 import com.danny.ewf_service.payload.request.ProductInventorySearchRequestDto;
 import com.danny.ewf_service.payload.response.ComponentInventoryResponseDto;
 import com.danny.ewf_service.payload.response.PagingResponse;
@@ -39,6 +40,18 @@ public class InventoryController {
                             productInventorySearchRequestDto.getPage()-1
                             ,productInventorySearchRequestDto.getSku());
             return ResponseEntity.ok(productInventoryResponseDtoList);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(404).body("Not found");
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body("Error fetching product");
+        }
+    }
+
+    @PutMapping("/components")
+    public ResponseEntity<?> updateComponentInventory(@RequestBody ComponentInventoryRequestDto componentInventoryRequestDto) {
+        try {
+            ComponentInventoryResponseDto newComponentInventoryResponseDto = inventoryService.updateComponent(componentInventoryRequestDto);
+            return ResponseEntity.ok(newComponentInventoryResponseDto);
         } catch (RuntimeException e) {
             return ResponseEntity.status(404).body("Not found");
         } catch (Exception e) {

--- a/src/main/java/com/danny/ewf_service/converter/IComponentMapper.java
+++ b/src/main/java/com/danny/ewf_service/converter/IComponentMapper.java
@@ -32,11 +32,15 @@ public interface IComponentMapper {
     @Mapping(target = "manufacturer", source = "component.manufacturer")
     @Mapping(target = "name", source = "component.name")
     @Mapping(target = "onPO", source = "component.report.onPO")
+    @Mapping(target = "toShip", source = "component.report.toShip")
+    @Mapping(target = "stockVN", source = "component.report.stockVN")
+    @Mapping(target = "inProduction", source = "component.report.inProduction")
     @Mapping(target = "inTransit", source = "component.report.inTransit")
-    @Mapping(target = "inStock", source = "component", qualifiedByName = "calculateInStock")
     @Mapping(target = "discontinue", source = "component.discontinue")
+    @Mapping(target = "inStock", source = "component", qualifiedByName = "calculateInStock")
     @Mapping(target = "report120Days", source = "component.report.salesReport", qualifiedByName = "calculate120DaysSale")
     @Mapping(target = "rating", source = "component", qualifiedByName = "calculateRating")
+    @Mapping(target = "stockStatus", source = "component", qualifiedByName = "calculateStockStatus")
     ComponentInventoryResponseDto componentToComponentInventoryResponseDto(Component component);
     List<ComponentInventoryResponseDto> componentListToComponentInventoryResponseDtoList(List<Component> components);
 
@@ -58,9 +62,52 @@ public interface IComponentMapper {
 
     @Named("calculateRating")
     default Double calculateRating(Component component) {
-        long inStock = component.getInventory() - component.getReport().getOnPO();
-        long c120days = component.getReport().getSalesReport()*2+1;
-        double rating = (double) (inStock + component.getReport().getInTransit()) /c120days;
+        double rating = (double) (calculateInStock(component) + component.getReport().getInTransit()) /calculate120DaysSale(component.getReport().getSalesReport());
         return Math.round(rating * 10) / 10.0;
+    }
+
+    @Named("calculateStockStatus")
+    default String calculateStockStatus(Component component) {
+        try {
+            long inStock = calculateInStock(component);
+            long calculate120days = calculate120DaysSale(component.getReport().getSalesReport());
+            double sum = inStock
+                    + calculateRating(component)
+                    + component.getReport().getInTransit()
+                    + component.getReport().getToShip();
+            double ratio = sum / calculate120days;
+            if (component.getDiscontinue()) {
+                return "P-Không SX";
+            } else if (sum == 0) {
+                return (calculate120days > sum) ? "A-Đưa Vào SX" : "";
+            } else if (ratio > 3) {
+                return "O-Hơn 1 năm";
+            } else if (ratio > 2.5) {
+                return "N-10 Tháng";
+            } else if (ratio > 2) {
+                return "M-8 Tháng";
+            } else if (ratio > 1.5) {
+                return "L-6 Tháng";
+            } else if (ratio > 1) {
+                return "K-4 Tháng";
+            } else if (ratio > 0.75) {
+                return "I-3 tháng";
+            } else if (ratio > 0.63) {
+                return "H-2.5 Tháng";
+            } else if (ratio > 0.5) {
+                return "G-2 Tháng";
+            } else if (ratio > 0.38) {
+                return "E-45 Ngày";
+            } else if (ratio > 0.25) {
+                return "D-30 Ngày";
+            } else if (ratio > 0.13) {
+                return "C-15 Ngày";
+            } else {
+                return "B-Hết Hàng";
+            }
+        } catch (Exception e) {
+            System.err.println(e.getMessage());
+        }
+        return "B-Hết Hàng";
     }
 }

--- a/src/main/java/com/danny/ewf_service/entity/Report.java
+++ b/src/main/java/com/danny/ewf_service/entity/Report.java
@@ -25,6 +25,15 @@ public class Report {
     @Column(name="in_transit")
     private Long inTransit = 0L;
 
+    @Column(name="to_ship")
+    private Long toShip = 0L;
+
+    @Column(name="stock_vn")
+    private Long stockVN = 0L;
+
+    @Column(name="in_production")
+    private Long inProduction = 0L;
+
     @Column(name="missing_report")
     private Long missingReport = 0L;
 

--- a/src/main/java/com/danny/ewf_service/payload/request/ComponentInventoryRequestDto.java
+++ b/src/main/java/com/danny/ewf_service/payload/request/ComponentInventoryRequestDto.java
@@ -1,0 +1,22 @@
+package com.danny.ewf_service.payload.request;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Setter
+@Getter
+@ToString
+@Data
+public class ComponentInventoryRequestDto {
+    private Long id;
+    private String name;
+    private Long inventory;
+    private Boolean discontinue;
+    private Long toShip;
+    private Long onPO;
+    private Long inTransit;
+    private Long stockVN;
+    private Long inProduction;
+}

--- a/src/main/java/com/danny/ewf_service/payload/response/ComponentInventoryResponseDto.java
+++ b/src/main/java/com/danny/ewf_service/payload/response/ComponentInventoryResponseDto.java
@@ -26,4 +26,8 @@ public class ComponentInventoryResponseDto {
     private Long onPO = 0L;
     private Long inTransit = 0L;
     private Double rating = 0.0;
+    private Long toShip = 0L;
+    private Long stockVN = 0L;
+    private Long inProduction = 0L;
+    private String stockStatus = "";
 }

--- a/src/main/java/com/danny/ewf_service/repository/ComponentRepository.java
+++ b/src/main/java/com/danny/ewf_service/repository/ComponentRepository.java
@@ -17,4 +17,7 @@ public interface ComponentRepository extends JpaRepository<Component, Long> {
 
     @Query("SELECT c FROM Component c JOIN FETCH c.report")
     List<Component> findAllComponents();
+
+    @Query("SELECT c FROM Component c JOIN FETCH c.report WHERE c.id = :id")
+    Component findComponentById(@Param("id") Long id);
 }

--- a/src/main/java/com/danny/ewf_service/service/ComponentService.java
+++ b/src/main/java/com/danny/ewf_service/service/ComponentService.java
@@ -13,4 +13,6 @@ public interface ComponentService {
     List<Component> findAllComponents();
 
     void linkComponentsToReports();
+
+    Component findComponentById(Long id);
 }

--- a/src/main/java/com/danny/ewf_service/service/InventoryService.java
+++ b/src/main/java/com/danny/ewf_service/service/InventoryService.java
@@ -1,5 +1,6 @@
 package com.danny.ewf_service.service;
 
+import com.danny.ewf_service.payload.request.ComponentInventoryRequestDto;
 import com.danny.ewf_service.payload.response.ComponentInventoryResponseDto;
 import com.danny.ewf_service.payload.response.PagingResponse;
 import com.danny.ewf_service.payload.response.ProductInventoryResponseDto;
@@ -16,4 +17,6 @@ public interface InventoryService {
     Long getInventoryProductCountById(Long id);
 
     List<ComponentInventoryResponseDto> findAllComponentsInventory();
+
+    ComponentInventoryResponseDto updateComponent(ComponentInventoryRequestDto componentInventoryRequestDto);
 }

--- a/src/main/java/com/danny/ewf_service/service/impl/ComponentServiceImpl.java
+++ b/src/main/java/com/danny/ewf_service/service/impl/ComponentServiceImpl.java
@@ -61,4 +61,9 @@ public class ComponentServiceImpl implements ComponentService {
             componentRepository.save(component);
         }
     }
+
+    @Override
+    public Component findComponentById(Long id) {
+        return componentRepository.findComponentById(id);
+    }
 }

--- a/src/main/java/com/danny/ewf_service/service/impl/InventoryServiceImpl.java
+++ b/src/main/java/com/danny/ewf_service/service/impl/InventoryServiceImpl.java
@@ -4,8 +4,10 @@ import com.danny.ewf_service.converter.IComponentMapper;
 import com.danny.ewf_service.converter.IProductMapper;
 import com.danny.ewf_service.entity.Component;
 import com.danny.ewf_service.entity.Product;
+import com.danny.ewf_service.payload.request.ComponentInventoryRequestDto;
 import com.danny.ewf_service.payload.response.ComponentInventoryResponseDto;
 import com.danny.ewf_service.payload.response.ProductInventoryResponseDto;
+import com.danny.ewf_service.repository.ComponentRepository;
 import com.danny.ewf_service.repository.ProductComponentRepository;
 import com.danny.ewf_service.repository.ProductRepository;
 import com.danny.ewf_service.repository.inventory.ProductInventorySearching;
@@ -40,6 +42,9 @@ public class InventoryServiceImpl implements InventoryService {
     private final IComponentMapper componentMapper;
 
     @Autowired
+    private final ComponentRepository componentRepository;
+
+    @Autowired
     private final ComponentService componentService;
 
     @Autowired
@@ -72,6 +77,21 @@ public class InventoryServiceImpl implements InventoryService {
     public List<ComponentInventoryResponseDto> findAllComponentsInventory() {
         List<Component> components = componentService.findAllComponents();
         return componentMapper.componentListToComponentInventoryResponseDtoList(components);
+    }
+
+    @Override
+    public ComponentInventoryResponseDto updateComponent(ComponentInventoryRequestDto componentInventoryRequestDto) {
+        Component component = componentService.findComponentById(componentInventoryRequestDto.getId());
+        component.setName(componentInventoryRequestDto.getName());
+        component.setInventory(componentInventoryRequestDto.getInventory());
+        component.setDiscontinue(componentInventoryRequestDto.getDiscontinue());
+        component.getReport().setInProduction(componentInventoryRequestDto.getInProduction());
+        component.getReport().setOnPO(componentInventoryRequestDto.getOnPO());
+        component.getReport().setToShip(componentInventoryRequestDto.getToShip());
+        component.getReport().setInTransit(componentInventoryRequestDto.getInTransit());
+        component.getReport().setStockVN(componentInventoryRequestDto.getStockVN());
+        componentRepository.save(component);
+        return componentMapper.componentToComponentInventoryResponseDto(component);
     }
 
     private Long parseObjectToLong(Object object){

--- a/src/main/java/com/danny/ewf_service/utils/imports/ComponentsImport.java
+++ b/src/main/java/com/danny/ewf_service/utils/imports/ComponentsImport.java
@@ -316,7 +316,8 @@ public class ComponentsImport {
                     Optional<Component> optionalComponent = componentRepository.findBySku(componentSku);
                     if (optionalComponent.isPresent()) {
                         component = optionalComponent.get();
-                        component.getReport().setInTransit((long) Math.ceil(Double.parseDouble(quantity)));
+//                        component.getReport().setInProduction((long) Math.ceil(Double.parseDouble(quantity)));
+                        component.setDiscontinue(true);
                         componentRepository.save(component);
                         System.out.println("Successfully Updated Component SKU : " + componentSku + " VALUES : " + quantity);
                     }


### PR DESCRIPTION
Introduce an API to update component inventory via `PUT /components`. This includes modifications to handle new fields in `ComponentInventoryRequestDto`, calculation logic for stock statuses, and integration with the `ComponentRepository`.