### PR TITLE
Update branch reference in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [closed]
     branches:
-      - main
+      - master
 
 jobs:
   test_and_build:


### PR DESCRIPTION
Replaced 'main' with 'master' in branch list for pull request events. This ensures the workflow triggers correctly on the intended branch.