### PR TITLE
Update artifact upload/download actions to specific versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: mvn -B package -DskipTests
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: app-build
           path: target/*.jar
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: app-build
 


### PR DESCRIPTION
Upgraded `actions/upload-artifact` to v3.1.2 and adjusted `actions/download-artifact` to v3 for improved compatibility and stability. This ensures consistent behavior and maintains compatibility with the latest action updates.