### PR TITLE
Upgrade upload-artifact action to v3.2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: mvn -B package -DskipTests
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v3.2.0
         with:
           name: app-build
           path: target/*.jar


### PR DESCRIPTION
Updated the GitHub Actions workflow to use the latest version of the upload-artifact action. This ensures improved compatibility and potential bug fixes from the newer release.