### PR TITLE
Update GitHub Actions to use latest action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 23
         uses: actions/setup-java@v3
@@ -30,7 +30,7 @@ jobs:
         run: mvn -B package -DskipTests
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3.2.0
+        uses: actions/upload-artifact@v4
         with:
           name: app-build
           path: target/*.jar
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Download build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: app-build
 


### PR DESCRIPTION
Upgraded actions/checkout, actions/upload-artifact, and actions/download-artifact to their v4 versions. This ensures compatibility with the latest features and improvements for better workflow performance.