### PR TITLE
Update Maven Compiler Plugin to version 3.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,12 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.13.0</version>
+
 				<configuration>
+					<source>23</source> <!-- Set your JDK version -->
+					<target>23</target>
+
 					<annotationProcessorPaths>
 						<path>
 							<groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Upgraded the Maven Compiler Plugin to 3.13.0 and set the Java source and target levels to 23. This ensures compatibility with the latest JDK features and improves build configuration clarity.