### PR TITLE
Add price field to ProductDetailResponseDto and mapping logic

### DIFF
--- a/src/main/java/com/danny/ewf_service/payload/response/product/ProductDetailResponseDto.java
+++ b/src/main/java/com/danny/ewf_service/payload/response/product/ProductDetailResponseDto.java
@@ -1,6 +1,7 @@
 package com.danny.ewf_service.payload.response.product;
 
 import com.danny.ewf_service.entity.ImageUrls;
+import com.danny.ewf_service.entity.Price;
 import com.danny.ewf_service.payload.response.component.ComponentProductDetailResponseDto;
 import lombok.*;
 
@@ -32,6 +33,7 @@ public class ProductDetailResponseDto {
     private String category;
     private String mainCategory;
     private String subCategory;
+    private Price price;
     private List<ComponentProductDetailResponseDto> components;
     private Boolean amazon = false;
     private Boolean cymax = false;

--- a/src/main/java/com/danny/ewf_service/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/danny/ewf_service/service/impl/ProductServiceImpl.java
@@ -33,6 +33,7 @@ public class ProductServiceImpl implements ProductService {
     @Autowired
     private final SKUGenerator skuGenerator;
 
+    @Autowired
     private final IProductMapper productMapper;
 
     @Autowired
@@ -49,6 +50,7 @@ public class ProductServiceImpl implements ProductService {
 
     @Autowired
     private InventoryService inventoryService;
+
     @Autowired
     private ImageService imageService;
 
@@ -460,6 +462,7 @@ public class ProductServiceImpl implements ProductService {
             if (product.getShippingMethod() != null) responseDto.setShippingMethod(product.getShippingMethod());
             if (product.getType() != null) responseDto.setType(product.getType());
             if (product.getDiscontinued() != null) responseDto.setDiscontinued(product.getDiscontinued());
+            if (product.getPrice() != null) responseDto.setPrice(product.getPrice());
 
 
             // Wholesale mappings


### PR DESCRIPTION
Introduce a new `price` field in `ProductDetailResponseDto` and update `ProductServiceImpl` to include mapping logic for it. This ensures the product price is properly populated in the response DTO.