### PR TITLE
Update endpoint for fetching product price by SKU

### DIFF
--- a/src/main/java/com/danny/ewf_service/controller/ProductController.java
+++ b/src/main/java/com/danny/ewf_service/controller/ProductController.java
@@ -95,7 +95,7 @@ public class ProductController {
         }
     }
 
-    @GetMapping("/{sku}?price")
+    @GetMapping("/price/{sku}")
     public ResponseEntity<?> getProductPrice(@PathVariable String sku) {
         try {
             ProductPriceResponseDto productPriceResponseDto = productService.getProductPrice(sku);


### PR DESCRIPTION
Changed the URL mapping from "/{sku}?price" to "/price/{sku}" for better clarity and RESTful compliance. This ensures the endpoint naming aligns with standard practices and improves URL readability.