### PR TITLE
Enhance price retrieval by adding component support

### DIFF
--- a/src/main/java/com/danny/ewf_service/converter/IComponentMapper.java
+++ b/src/main/java/com/danny/ewf_service/converter/IComponentMapper.java
@@ -2,10 +2,12 @@ package com.danny.ewf_service.converter;
 
 import com.danny.ewf_service.entity.Component;
 import com.danny.ewf_service.entity.ImageUrls;
+import com.danny.ewf_service.entity.product.Product;
 import com.danny.ewf_service.payload.response.component.ComponentInboundResponseDto;
 import com.danny.ewf_service.payload.response.component.ComponentInventoryResponseDto;
 import com.danny.ewf_service.payload.response.component.ComponentListWMSResponse;
 import com.danny.ewf_service.payload.response.component.ComponentResponseDto;
+import com.danny.ewf_service.payload.response.product.ProductPriceResponseDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -29,6 +31,12 @@ public interface IComponentMapper {
     @Mapping(target = "inventory", source = "component.inventory")
     ComponentResponseDto componentToComponentResponseDto(Component component);
     List<ComponentResponseDto> componentListToComponentResponseDtoList(List<Component> components);
+
+    @Mapping(target = "sku", source = "component.sku")
+    @Mapping(target = "QB1", source = "component.price.QB1")
+    @Mapping(target = "QB3", source = "component.price.QB3")
+    @Mapping(target = "QB7", source = "component.price.QB7")
+    ProductPriceResponseDto componentToProductPriceResponseDto(Component component);
 
 
     @Mapping(target = "id", source = "component.id")

--- a/src/main/java/com/danny/ewf_service/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/danny/ewf_service/service/impl/ProductServiceImpl.java
@@ -1,5 +1,6 @@
 package com.danny.ewf_service.service.impl;
 
+import com.danny.ewf_service.converter.IComponentMapper;
 import com.danny.ewf_service.converter.IProductMapper;
 import com.danny.ewf_service.entity.Component;
 import com.danny.ewf_service.entity.Dimension;
@@ -15,6 +16,7 @@ import com.danny.ewf_service.payload.response.product.ProductDetailResponseDto;
 import com.danny.ewf_service.payload.response.product.ProductPriceResponseDto;
 import com.danny.ewf_service.payload.response.product.ProductResponseDto;
 import com.danny.ewf_service.payload.response.product.ProductSearchResponseDto;
+import com.danny.ewf_service.repository.ComponentRepository;
 import com.danny.ewf_service.repository.ProductComponentRepository;
 import com.danny.ewf_service.repository.ProductRepository;
 import com.danny.ewf_service.service.*;
@@ -38,6 +40,9 @@ public class ProductServiceImpl implements ProductService {
     private final IProductMapper productMapper;
 
     @Autowired
+    private final IComponentMapper componentMapper;
+
+    @Autowired
     private final ProductRepository productRepository;
 
     @Autowired
@@ -51,6 +56,9 @@ public class ProductServiceImpl implements ProductService {
 
     @Autowired
     private InventoryService inventoryService;
+
+    @Autowired
+    private final ComponentRepository componentRepository;
 
     @Autowired
     private ImageService imageService;
@@ -322,9 +330,13 @@ public class ProductServiceImpl implements ProductService {
     @Override
     public ProductPriceResponseDto getProductPrice(String sku) {
         Optional<Product> optionalProduct = productRepository.findProductBySku(sku);
+        Optional<Component> optionalComponent = componentRepository.findBySku(sku);
         if (optionalProduct.isPresent()) {
             Product product = optionalProduct.get();
             return productMapper.productToProductPriceResponseDto(product);
+        } else if (optionalComponent.isPresent()) {
+            Component component = optionalComponent.get();
+            return componentMapper.componentToProductPriceResponseDto(component);
         }
         return null;
     }


### PR DESCRIPTION
Extended the `getProductPrice` method to handle components alongside products using `componentRepository` and `componentMapper`. Introduced a new mapping method in `IComponentMapper` to map components to `ProductPriceResponseDto`.