### PR TITLE
Update dimension handling in Product and LPN services

### DIFF
--- a/src/main/java/com/danny/ewf_service/payload/request/product/ProductDetailRequestDto.java
+++ b/src/main/java/com/danny/ewf_service/payload/request/product/ProductDetailRequestDto.java
@@ -41,4 +41,5 @@ public class ProductDetailRequestDto {
     private ImageUrls images;
     private Double ewfdirectManualPrice;
     private Long promotion;
+    private String dimension;
 }

--- a/src/main/java/com/danny/ewf_service/payload/response/product/ProductDetailResponseDto.java
+++ b/src/main/java/com/danny/ewf_service/payload/response/product/ProductDetailResponseDto.java
@@ -47,5 +47,6 @@ public class ProductDetailResponseDto {
     private Double ewfdirectPrice;
     private Double ewfdirectManualPrice;
     private Long promotion;
+    private String dimension;
 }
 

--- a/src/main/java/com/danny/ewf_service/service/impl/LpnServiceImpl.java
+++ b/src/main/java/com/danny/ewf_service/service/impl/LpnServiceImpl.java
@@ -27,9 +27,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 
-import javax.swing.text.html.Option;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -309,9 +307,10 @@ public class LpnServiceImpl implements LpnService {
             // Your insert query
             try (Connection connection = DriverManager.getConnection(url, dbUser, dbPassword);
                  PreparedStatement preparedStatement = connection.prepareStatement(insertQuery)) {
-
+                String baycode = "";
+                if (lpn.getBayLocation() != null) baycode = lpn.getBayLocation().getBayCode();
                 // Setting the values for the placeholders
-                preparedStatement.setString(1, lpn.getBayLocation().getBayCode() != null ? lpn.getBayLocation().getBayCode() : "");
+                preparedStatement.setString(1, baycode);
                 preparedStatement.setString(2, lpn.getTagID());
                 preparedStatement.setInt(3, Math.toIntExact(lpn.getQuantity()));
                 preparedStatement.setString(4, lpn.getComponent().getSku());

--- a/src/main/java/com/danny/ewf_service/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/danny/ewf_service/service/impl/ProductServiceImpl.java
@@ -516,12 +516,11 @@ public class ProductServiceImpl implements ProductService {
         if (dto.getHoustondirect() != null) product.getWholesales().setHoustonDirect(dto.getHoustondirect());
         if (dto.getEwfmain() != null) product.getWholesales().setEwfmain(dto.getEwfmain());
 
-        if (dto.getSizeShape() != null) {
-            Dimension dimension = product.getDimension();
-            if (dimension == null) dimension = new Dimension();
-            dimension.setSizeShape(dto.getSizeShape());
-            product.setDimension(dimension);
-        }
+        Dimension dimension = product.getDimension();
+        if (dimension == null) dimension = new Dimension();
+        dimension.setSizeShape(dto.getSizeShape());
+        dimension.setLwh(dto.getDimension());
+        product.setDimension(dimension);
 
         if (dto.getComponents() != null) {
             List<ProductComponent> components = new ArrayList<>();
@@ -596,7 +595,10 @@ public class ProductServiceImpl implements ProductService {
             }
 
             // Dimension mappings
-            if (product.getDimension() != null) responseDto.setSizeShape(product.getDimension().getSizeShape());
+            if (product.getDimension() != null) {
+                responseDto.setSizeShape(product.getDimension().getSizeShape());
+                responseDto.setDimension(product.getDimension().getLwh());
+            }
 
             List<ComponentProductDetailResponseDto> componentList = new ArrayList<>();
             if (product.getComponents() != null) {


### PR DESCRIPTION
Refactor `dimension` mapping logic in `ProductServiceImpl` to include `sizeShape` and `lwh`. Adjust `LpnServiceImpl` to streamline `bayCode` assignment and remove unused imports. Add `dimension` field to product request and response DTOs for better data consistency.