### PR TITLE
Sort orders by updatedAt in descending order.

### DIFF
--- a/src/main/java/com/danny/ewf_service/service/impl/OrderServiceImpl.java
+++ b/src/main/java/com/danny/ewf_service/service/impl/OrderServiceImpl.java
@@ -11,9 +11,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.jaxb.SpringDataJaxb;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @AllArgsConstructor
@@ -28,6 +31,17 @@ public class OrderServiceImpl implements OrderService {
     @Override
     public List<OrderListResponseDto> getAllOrders() {
         List<Order> orders = orderRepository.findAll();
-        return IOrderMapper.orderToOrderListResponseDtos(orders);
+        List<OrderListResponseDto> orderDtoList = IOrderMapper.orderToOrderListResponseDtos(orders);
+        orderDtoList = sortOrdersByUpdatedAt(orderDtoList);
+
+        return orderDtoList;
+
+
+
+    }
+    public List<OrderListResponseDto> sortOrdersByUpdatedAt(List < OrderListResponseDto> orderDtoList) {
+        return orderDtoList.stream()
+                .sorted(Comparator.comparing(OrderListResponseDto::getUpdatedAt).reversed()) // Sort by updatedAt in descending order
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Introduced sorting for order DTOs in the `getAllOrders` method to ensure the list is returned in descending order of the `updatedAt` field. Added a helper method `sortOrdersByUpdatedAt` utilizing Java Streams for sorting logic.