### PR TITLE
Add method to update product components from sheet data

### DIFF
--- a/src/main/java/com/danny/ewf_service/controller/ProductController.java
+++ b/src/main/java/com/danny/ewf_service/controller/ProductController.java
@@ -1,9 +1,10 @@
 package com.danny.ewf_service.controller;
 
 import com.danny.ewf_service.payload.projection.ProductComponentDto;
-import com.danny.ewf_service.payload.request.ComponentSheetRequestDto;
+import com.danny.ewf_service.payload.request.product.ProductComponentRequestDto;
 import com.danny.ewf_service.payload.request.product.ProductDetailRequestDto;
 import com.danny.ewf_service.payload.request.product.ProductSheetRequestDto;
+import com.danny.ewf_service.payload.request.sheet.SkuComponentsDto;
 import com.danny.ewf_service.payload.response.product.ProductDetailResponseDto;
 import com.danny.ewf_service.payload.response.product.ProductPriceResponseDto;
 import com.danny.ewf_service.payload.response.product.ProductResponseDto;
@@ -131,6 +132,18 @@ public class ProductController {
     public ResponseEntity<?> updateProductFromSheet(@RequestBody List<ProductSheetRequestDto> productSheetRequestDtos) {
         try {
             LocalDateTime updated = productService.updateProductFromSheet(productSheetRequestDtos);
+            return ResponseEntity.ok(updated);
+        } catch (RuntimeException e) {
+            return ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.internalServerError().body("Error fetching product");
+        }
+    }
+
+    @PostMapping("/pc")
+    public ResponseEntity<?> updateProductComponentFromSheet(@RequestBody List<SkuComponentsDto> skuComponentsDtos) {
+        try {
+            LocalDateTime updated = productService.updateProductComponentFromSheet(skuComponentsDtos);
             return ResponseEntity.ok(updated);
         } catch (RuntimeException e) {
             return ResponseEntity.notFound().build();

--- a/src/main/java/com/danny/ewf_service/payload/request/sheet/ComponentItemDto.java
+++ b/src/main/java/com/danny/ewf_service/payload/request/sheet/ComponentItemDto.java
@@ -1,0 +1,16 @@
+package com.danny.ewf_service.payload.request.sheet;
+
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Setter
+@Getter
+@ToString
+public class ComponentItemDto {
+    private String sku;
+    private Long pcs;
+}

--- a/src/main/java/com/danny/ewf_service/payload/request/sheet/SkuComponentsDto.java
+++ b/src/main/java/com/danny/ewf_service/payload/request/sheet/SkuComponentsDto.java
@@ -1,0 +1,18 @@
+package com.danny.ewf_service.payload.request.sheet;
+
+
+import lombok.*;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@Setter
+@Getter
+@ToString
+public class SkuComponentsDto {
+    private String productSku;
+    private List<ComponentItemDto> components;
+}

--- a/src/main/java/com/danny/ewf_service/service/ProductService.java
+++ b/src/main/java/com/danny/ewf_service/service/ProductService.java
@@ -7,6 +7,7 @@ import com.danny.ewf_service.payload.projection.ProductComponentDto;
 import com.danny.ewf_service.payload.projection.ProductManagementDto;
 import com.danny.ewf_service.payload.request.product.ProductDetailRequestDto;
 import com.danny.ewf_service.payload.request.product.ProductSheetRequestDto;
+import com.danny.ewf_service.payload.request.sheet.SkuComponentsDto;
 import com.danny.ewf_service.payload.response.product.ProductDetailResponseDto;
 import com.danny.ewf_service.payload.response.product.ProductPriceResponseDto;
 import com.danny.ewf_service.payload.response.product.ProductResponseDto;
@@ -38,4 +39,6 @@ public interface ProductService {
     void updateSubProduct();
 
     LocalDateTime updateProductFromSheet(List<ProductSheetRequestDto> products);
+
+    LocalDateTime updateProductComponentFromSheet(List<SkuComponentsDto> skuComponentsDtos);
 }

--- a/src/main/java/com/danny/ewf_service/service/impl/ProductServiceImpl.java
+++ b/src/main/java/com/danny/ewf_service/service/impl/ProductServiceImpl.java
@@ -14,6 +14,8 @@ import com.danny.ewf_service.payload.request.product.ProductComponentRequestDto;
 import com.danny.ewf_service.payload.request.product.ProductDetailRequestDto;
 import com.danny.ewf_service.entity.product.ProductComponent;
 import com.danny.ewf_service.payload.request.product.ProductSheetRequestDto;
+import com.danny.ewf_service.payload.request.sheet.ComponentItemDto;
+import com.danny.ewf_service.payload.request.sheet.SkuComponentsDto;
 import com.danny.ewf_service.payload.response.component.ComponentProductDetailResponseDto;
 import com.danny.ewf_service.payload.response.product.ProductDetailResponseDto;
 import com.danny.ewf_service.payload.response.product.ProductPriceResponseDto;
@@ -142,6 +144,53 @@ public class ProductServiceImpl implements ProductService {
         productRepository.saveAll(productsToSave);
 
         // Return the timestamp of the operation
+        return LocalDateTime.now();
+    }
+
+    @Override
+    public LocalDateTime updateProductComponentFromSheet(List<SkuComponentsDto> skuComponentsDtos) {
+        if (skuComponentsDtos == null || skuComponentsDtos.isEmpty()) return LocalDateTime.now();
+        for (SkuComponentsDto dto : skuComponentsDtos) {
+            Optional<Product> optionalProduct = productRepository.findProductBySku(dto.getProductSku().toUpperCase());
+            if (optionalProduct.isPresent()) {
+                Product product = optionalProduct.get();
+                // Step 1: Retrieve and clear the current components list
+                List<ProductComponent> productComponents = product.getComponents();
+                productComponents.clear();
+
+                // Persist clearing to avoid duplicate entries
+                productRepository.save(product);
+
+                // Step 2: Create and add new ProductComponents from dto
+                List<ProductComponent> newComponents = new ArrayList<>();
+                for (ComponentItemDto componentDto : dto.getComponents()) {
+                    if (componentDto.getPcs() < 1) continue;
+                    // Retrieve the Component entity by SKU
+                    Optional<Component> optionalComponent = componentRepository.findBySku(componentDto.getSku());
+                    if (optionalComponent.isPresent()) {
+                        Component component = optionalComponent.get();
+
+                        // Create a new ProductComponent and set its properties
+                        ProductComponent productComponent = ProductComponent.builder()
+                                .product(product)
+                                .component(component)
+                                .quantity(componentDto.getPcs())
+                                .build();
+
+                        newComponents.add(productComponent);
+                    }
+                }
+                // Add all new components to the product's component list
+                productComponents.addAll(newComponents);
+                // Step 3: Save the updated product
+                productRepository.save(product);
+
+
+            } else {
+                return LocalDateTime.now();
+            }
+        }
+
         return LocalDateTime.now();
     }
 


### PR DESCRIPTION
Introduced a new endpoint and service logic to update product components based on sheet input data (`SkuComponentsDto`). This includes clearing existing components and adding new ones derived from the provided sheet, ensuring accurate updates to the product's component list.