### PR TITLE
Add Amazon price field to Product repository and DTO

### DIFF
--- a/src/main/java/com/danny/ewf_service/payload/projection/ProductPriceDto.java
+++ b/src/main/java/com/danny/ewf_service/payload/projection/ProductPriceDto.java
@@ -7,4 +7,6 @@ public interface ProductPriceDto {
     Double getManualShippingCost();
     Double getPromotion();
     Double getEwfdirectManualPrice();
+
+    Double getAmazonPrice();
 }

--- a/src/main/java/com/danny/ewf_service/repository/ProductRepository.java
+++ b/src/main/java/com/danny/ewf_service/repository/ProductRepository.java
@@ -192,7 +192,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
             pr.shippingCost as shippingCost,
             pr.manualShippingCost as manualShippingCost,
             pr.promotion as promotion,
-            pr.ewfdirectManualPrice as ewfdirectManualPrice
+            pr.ewfdirectManualPrice as ewfdirectManualPrice,
+            pr.amazonPrice as amazonPrice
             
         FROM Product p
         LEFT JOIN p.price pr


### PR DESCRIPTION
Include the `amazonPrice` field in the Product repository query and the ProductPriceDto projection. This allows for retrieval and mapping of Amazon price data for relevant products.