### PR TITLE
Remove unused ProductService field from ComponentsImport

### DIFF
--- a/src/main/java/com/danny/ewf_service/utils/imports/ComponentsImport.java
+++ b/src/main/java/com/danny/ewf_service/utils/imports/ComponentsImport.java
@@ -57,9 +57,6 @@ public class ComponentsImport {
     private final ProductRepository productRepository;
 
     @Autowired
-    private final ProductService productService;
-
-    @Autowired
     private final ComponentRepository componentRepository;
 
     @Autowired


### PR DESCRIPTION
The ProductService field was declared but never used, leading to unnecessary code clutter. Removing it helps improve code readability and maintainability.