### PR TITLE
Add shipping cost field to Shopify order handling

### DIFF
--- a/src/main/java/com/danny/ewf_service/entity/ShopifyOrder.java
+++ b/src/main/java/com/danny/ewf_service/entity/ShopifyOrder.java
@@ -25,4 +25,7 @@ public class ShopifyOrder {
 
     @Column(name = "sale_receipt")
     private String saleReceipt;
+
+    @Column(name = "shipping_cost")
+    private Double shippingCost;
 }

--- a/src/main/java/com/danny/ewf_service/payload/request/sheet/ShopifyOrderRequestDto.java
+++ b/src/main/java/com/danny/ewf_service/payload/request/sheet/ShopifyOrderRequestDto.java
@@ -14,4 +14,5 @@ public class ShopifyOrderRequestDto {
     private String orderID;
     private String note;
     private String saleReceipt;
+    private String shippingCost;
 }

--- a/src/main/java/com/danny/ewf_service/service/impl/ShopifyOrderServiceImpl.java
+++ b/src/main/java/com/danny/ewf_service/service/impl/ShopifyOrderServiceImpl.java
@@ -26,6 +26,7 @@ public class ShopifyOrderServiceImpl implements ShopifyOrderService {
         }
         shopifyOrder.setNote(shopifyOrderRequestDto.getNote().trim());
         shopifyOrder.setSaleReceipt(shopifyOrderRequestDto.getSaleReceipt().trim());
+        shopifyOrder.setShippingCost(Double.valueOf(shopifyOrderRequestDto.getShippingCost()));
         shopifyOrderRepository.save(shopifyOrder);
     }
 


### PR DESCRIPTION
Introduced a new `shippingCost` field in `ShopifyOrder`, `ShopifyOrderRequestDto`, and related service implementation. This allows the system to handle and persist shipping cost data for orders.