### PR TITLE
Remove unused ProductComponentRepository from ProductsImport

### DIFF
--- a/src/main/java/com/danny/ewf_service/utils/imports/ProductsImport.java
+++ b/src/main/java/com/danny/ewf_service/utils/imports/ProductsImport.java
@@ -35,9 +35,6 @@ public class ProductsImport {
     private final ProductRepository productRepository;
 
     @Autowired
-    private final ProductComponentRepository productComponentRepository;
-
-    @Autowired
     private final ComponentRepository componentRepository;
 
     @Autowired


### PR DESCRIPTION
The ProductComponentRepository field was declared but never used in the ProductsImport class and has now been removed. This cleanup reduces unnecessary code and improves maintainability.